### PR TITLE
Redirect users to streetlightR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
 # StreetLight-API
 Making API calls to the StreetLight data platform using the R language

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 > [!IMPORTANT]
-> Key information users need to know to achieve their goal.
+> This repository has been superseded by [streetlightR](https://github.com/Metropolitan-Council/streetlightR), an R wrapper for StreetLight InSight® API. 
+
 
 # StreetLight-API
 Making API calls to the StreetLight data platform using the R language


### PR DESCRIPTION
We have continued to adapt the code you started back in 2019, and made an R package, [streetlightR](https://github.com/Metropolitan-Council/streetlightR). If you would like to be added as a contributor, please let me know and I will add you in the next release. 

This pull-request adds a callout at the top of the README directing folks to the streetlightR repository. 

Additionally, if you are comfortable, I request that you archive this repository after this pull-request is complete. This will signal that there is no further development planned. You can un-archive a repository at any time. 